### PR TITLE
Added support for multiple slaves in Pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!groovy
-node('Django_slave') {
+node {
     try {
         stage 'Checkout'
           checkout scm


### PR DESCRIPTION
Removed the hardcoded slave name in the Jenkinsfile. After enabling in the Jenkins UI, we can now build jobs simultaneously.