### PR TITLE
Updates Google Auth to work with non localhost hostnames

### DIFF
--- a/TimeTracker/myapp/urls.py
+++ b/TimeTracker/myapp/urls.py
@@ -6,7 +6,7 @@ from . import views
 
 urlpatterns = [
     path('begin_google_auth/', views.begin_google_auth),
-    path('oauth2callback/', views.sheets_auth),
+    path('finish_google_auth/', views.finish_google_auth),
     path('', views.index, name='index'),
     path('login/', adminviews.LoginView.as_view()),
     path('register/', views.register),

--- a/TimeTracker/myapp/util.py
+++ b/TimeTracker/myapp/util.py
@@ -11,7 +11,7 @@ from googleapiclient.discovery import build
 def authenticate(user, api, version):
     """Returns google service"""
 
-    with open('/code/client_secret', 'r') as file:
+    with open('/code/client_secret.json', 'r') as file:
         client_secret_file = json.load(file)
     try:
         credentials = client.OAuth2Credentials(

--- a/TimeTracker/myapp/views.py
+++ b/TimeTracker/myapp/views.py
@@ -170,10 +170,10 @@ def sheets(request):
 def begin_google_auth(request):
     """Google Authentication"""
     flow = google_auth_oauthlib.flow.Flow.from_client_secrets_file(
-        '/code/client_secret',
+        '/code/client_secret.json',
         scopes=['https://www.googleapis.com/auth/drive']
     )
-    flow.redirect_uri = 'http://localhost:8000/oauth2callback'
+    flow.redirect_uri = request.build_absolute_uri('/finish_google_auth/')
     # pylint: disable=unused-variable
     authorization_url, state = flow.authorization_url(
         access_type='offline',
@@ -182,14 +182,14 @@ def begin_google_auth(request):
     return redirect(authorization_url)
 
 @login_required
-def sheets_auth(request):
+def finish_google_auth(request):
     """Called After Google Auth"""
     flow = google_auth_oauthlib.flow.Flow.from_client_secrets_file(
-        '/code/client_secret',
+        '/code/client_secret.json',
         scopes=['https://www.googleapis.com/auth/drive'],
     )
     code = request.GET.get('code', None)
-    flow.redirect_uri = 'http://localhost:8000/oauth2callback'
+    flow.redirect_uri = request.build_absolute_uri('/finish_google_auth/')
     flow.fetch_token(code=code)
     credentials = flow.credentials
 


### PR DESCRIPTION
When doing Google OAuth a redirect url must be provided for Google to redirect to after authentication. Previously this redirect was hardcoded to use localhost:8000

This update makes the redirect domain match the original domain the user came in on. Therefore it should work with both development and production. 